### PR TITLE
Complete repo URL to fix import error

### DIFF
--- a/Instructions/Labs/LAB_AK_14_implement-spec-driven-development.md
+++ b/Instructions/Labs/LAB_AK_14_implement-spec-driven-development.md
@@ -68,7 +68,7 @@ Use the following steps to complete this task:
 1. On the **Import your project to GitHub** page, under **Your source repository details**, enter the following URL for the source repository:
 
     ```plaintext
-    https://github.com/MicrosoftLearning/ContosoDashboard-SSD
+    https://github.com/MicrosoftLearning/ContosoDashboard-SSD.git
     ```
 
 1. Under the **Your new repository details** section, in the **Owner** dropdown, select your GitHub username.


### PR DESCRIPTION
# Lab/Demo: 14
## Implement a product feature using GitHub Spec Kit

Changes proposed in this pull request:

- Add `.git` to the URL for the `ContosoDashboard` repo. Without the extension, the repo will not import as described in the instructions.
