### PR TITLE
Revise slash command example in documentation

### DIFF
--- a/Instructions/Labs/LAB_AK_02_analyze_document_code.md
+++ b/Instructions/Labs/LAB_AK_02_analyze_document_code.md
@@ -165,7 +165,7 @@ Use the following steps to complete this section of the exercise:
     For example, enter the following prompt in the Chat view:
 
     ```plaintext
-    /explain #codebase Explain the Program.cs file
+    /explain #Program.cs
     ```
 
     Use slash commands, such as **/explain**, to specify the intent of your prompt. Communicating your intent helps GitHub Copilot understand the type of response that it needs to generate. The list of available slash commands may vary depending on your environment and the context of your chat.


### PR DESCRIPTION
Updated the slash command example for clarity.

# Module: 02
## Lab: Analyze and document code using GitHub Copilot

Fixes #47.

Changes proposed in this pull request:

- Shortened the explain command to the minimum.